### PR TITLE
Add variable support to include_sass tag

### DIFF
--- a/lib/jekyll/tags/include_sass.rb
+++ b/lib/jekyll/tags/include_sass.rb
@@ -6,9 +6,12 @@ module Jekyll
       include Jekyll::Filters
 
       def render(context)
+        file = render_variable(context) || @file
+        validate_file_name(file)
+
         @context = context
 
-        case File.extname(@file)
+        case File.extname(file)
         when '.sass'
           sassify(super)
         when '.scss'


### PR DESCRIPTION
Based on Jekyll's support for variables in include tag, I've added support for this to include_sass

See: https://github.com/jekyll/jekyll/blob/master/lib/jekyll/tags/include.rb

Fixes #6 